### PR TITLE
Chocolatey Allows Users to Install Specific Versions

### DIFF
--- a/docs/overview/Chocolatey-Comparison.md
+++ b/docs/overview/Chocolatey-Comparison.md
@@ -6,7 +6,6 @@
 - **Doesn't use NuGet.** NuGet is a great solution to the problem of managing software library dependencies. Scoop avoids this problem altogether: each program you install is isolated and independent.
 - **Simpler than packaging.** Scoop isn't a package manager, rather it reads plain JSON manifests that describe how to install a program and its dependencies.
 - **Simpler app repository.** Scoop just uses Git for its app repository. You can create your own repo, or even just a single file that describes an app to install.
-- **Can't always install a specific version of a program.** For some programs, scoop can install an older version of a program, via `scoop install app@version`. For example, `scoop install curl@7.56.1`. This functionality only works if the old version is still available online. Some older versions have specific installers, such as Python 2.7 and Ruby 1.9, which are commonly required. These can be installed from the [versions](https://github.com/scoopinstaller/versions) bucket via `scoop install python27` and `scoop install ruby19`.
 
 ::: tip NOTE
 While it would be easy to install Skype with Scoop, this will probably never be in Scoop's main bucket (app repository). Scoop focuses on open-source, command-line developer tools. The [scoop extras](https://github.com/lukesampson/scoop-extras) bucket is for non developer tools.


### PR DESCRIPTION
When you go to a package on Chocolatey's website, under "Version History" you can select a specific version of a package and install that. You can also do this without ever visiting Chocolatey's website by adding the version after the package name. For example, I could type, `choco install firefox --version=84.0` to install the old Firefox 84.