### PR TITLE
Add mention of PHP_INI_SCAN_DIR which impacts such settings

### DIFF
--- a/docs/guides/Custom-PHP-configuration.md
+++ b/docs/guides/Custom-PHP-configuration.md
@@ -5,6 +5,8 @@ If you want to customize the settings of your PHP Installation you should never 
 Always create you own custom configuration files inside the configuration scan dir.
 The directory is located at `~/scoop/persist/php/cli/conf.d`. You can create as many `.ini` files as you like.
 
+Be aware that this only applies once the `PHP_INI_SCAN_DIR` variable is set, which may not happen right after scoop was installed, and may require a restart. In case of doubt, you may check `php --ini` to make sure which files are loaded, depending on that env variable.
+
 ## Examples
 
 Some basic settings like the timezone and limits (`custom.ini`)


### PR DESCRIPTION
I happened to bang my head against differences between scoop installations relating to PHP .ini file customizations.
 
The differences were that I had restarted one and not the other of the systems. So the env variables weren't set, including PHP_INI_SCAN_DIR which affects the loading of .ini files in the .d dir.

This addresses for instance concerns of participants in the thread of  
https://github.com/ScoopInstaller/Scoop/issues/1609 for instance.

Hope this helps improving the docs.